### PR TITLE
Update ASG UpdatePolicy to reflect new rolling_update model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 Changelog for Paco
 ==================
 
-6.1.2 (unreleased)
+6.2.0 (unreleased)
 ------------------
+
+### Migration
+
+- ASG rolling_udpate_policy behaviour has been changed. The fields ``update_policy_max_batch_size`` and ``update_policy_min_instances_in_service``
+  have been removed and these settings are only controlled with the ``rolling_udpate_policy`` field.
 
 ### Changed
 

--- a/docs/yaml-monitoring.rst
+++ b/docs/yaml-monitoring.rst
@@ -510,7 +510,7 @@ This is a base schema which defines metadata useful to categorize an alarm.
       - 
     * - notification_groups
       - List<String>
-      - List of notificationn groups the alarm is subscribed to.
+      - List of notification groups the alarm is subscribed to.
       - 
       - 
     * - runbook_url

--- a/src/paco/application/ec2_launch_manager.py
+++ b/src/paco/application/ec2_launch_manager.py
@@ -525,7 +525,7 @@ statement:
       - '*'
 """.format(iam_policy_name)
         # Signal Resource permissions if its needed
-        if resource.rolling_update_policy != None and resource.rolling_update_policy.wait_on_resource_signals == True:
+        if resource.rolling_update_policy.wait_on_resource_signals == True:
             rolling_update_policy_table = {
                 'region': self.aws_region,
                 'stack_name': stack_name,

--- a/src/paco/cftemplates/asg.py
+++ b/src/paco/cftemplates/asg.py
@@ -28,10 +28,7 @@ class ASG(StackTemplate):
         self.env_ctx = env_ctx
         self.ec2_manager_cache_id = ec2_manager_cache_id
         segment_stack = self.env_ctx.get_segment_stack(asg_config.segment)
-        super().__init__(
-            stack,
-            paco_ctx,
-        )
+        super().__init__(stack, paco_ctx)
         self.set_aws_name('ASG', self.resource_group_name, self.resource_name)
 
         # Troposphere
@@ -54,7 +51,6 @@ class ASG(StackTemplate):
         # if the network for the ASG is disabled, only use an empty placeholder
         env_region = get_parent_by_interface(asg_config, schemas.IEnvironmentRegion)
         if not env_region.network.is_enabled():
-            self.set_template(template.to_yaml())
             return
 
         security_group_list_param = self.create_cfn_ref_list_param(
@@ -286,29 +282,26 @@ class ASG(StackTemplate):
         )
         template.add_resource(asg_res)
         asg_res.DependsOn = launch_config_res
-        max_batch_size = 1
-        min_instances_in_service = 0
-        pause_time = 'PT0S'
-        wait_on_resource_signals = False
-        if asg_config.is_enabled() == True:
-            if asg_config.rolling_update_policy != None:
-                if asg_config.rolling_update_policy.is_enabled():
-                    max_batch_size = asg_config.rolling_update_policy.max_batch_size
-                    min_instances_in_service = asg_config.rolling_update_policy.min_instances_in_service
-                    pause_time = asg_config.rolling_update_policy.pause_time
-                    wait_on_resource_signals = asg_config.rolling_update_policy.wait_on_resource_signals
-            else:
-                max_batch_size = asg_config.update_policy_max_batch_size
-                min_instances_in_service = asg_config.update_policy_min_instances_in_service
 
-        asg_res.UpdatePolicy = troposphere.policies.UpdatePolicy(
-            AutoScalingRollingUpdate=troposphere.policies.AutoScalingRollingUpdate(
-                MaxBatchSize=max_batch_size,
-                MinInstancesInService=min_instances_in_service,
-                PauseTime=pause_time,
-                WaitOnResourceSignals=wait_on_resource_signals
+        # only create an UpdatePolicy if it is enabled
+        breakpoint()
+        update_policy = asg_config.rolling_update_policy
+        if update_policy.enabled == True:
+            if update_policy.pause_time == '' and update_policy.wait_on_resource_signals == True:
+                # if wait_on_resource_signals is true the default pause time is 5 minutes
+                update_policy.pause_time = 'PT5M'
+            elif update_policy.pause_time == '':
+                update_policy.pause_time = 'PT0S'
+
+            # UpdatePolicy properties
+            asg_res.UpdatePolicy = troposphere.policies.UpdatePolicy(
+                AutoScalingRollingUpdate=troposphere.policies.AutoScalingRollingUpdate(
+                    MaxBatchSize=update_policy.max_batch_size,
+                    MinInstancesInService=update_policy.min_instances_in_service,
+                    PauseTime=update_policy.pause_time,
+                    WaitOnResourceSignals=update_policy.wait_on_resource_signals
+                )
             )
-        )
 
         self.create_output(
             title='ASGName',


### PR DESCRIPTION
This merges docs built from the paco.models PR, but also contains changes to asg.py that implement the new model changes. The model makes ASGRollingUpdatePolicy a required field and creates an object with default values in the constructor. This simplifies the asg code a fair bit.

Also review the `rolling_update_policy.enabled: false` which I propose won't set the policy at all. This would support the use case where you want to apply changes without modifying instances.

